### PR TITLE
[fix] Spec file updates

### DIFF
--- a/spec/game_statistics_spec.rb
+++ b/spec/game_statistics_spec.rb
@@ -33,48 +33,40 @@ RSpec.describe GameStatistics do
 
     describe '#total score stats' do
         it 'knows the highest total score' do
-        allow(@game_stats).to receive(:highest_total_score).and_return(11)
         expect(@game_stats.highest_total_score).to eq(11)
         end
 
         it 'knows the lowest total score' do
-        allow(@game_stats).to receive(:lowest_total_score).and_return(7)
         expect(@game_stats.lowest_total_score).to eq(7)
         end
     end
 
     describe '#win, loss, and tie percentages' do
         it 'knows the percentage of home wins' do
-        allow(@game_stats).to receive(:percentage_home_wins).and_return(.50)
         expect(@game_stats.percentage_home_wins).to eq(.50)
         end
 
         it 'knows the percentage of visitor wins' do
-        allow(@game_stats).to receive(:percentage_visitor_wins).and_return(.50)
         expect(@game_stats.percentage_visitor_wins).to eq(.50)
         end
 
         it 'knows the percentage of ties' do
-            allow(@game_stats).to receive(:percentage_ties).and_return(0.0)
             expect(@game_stats.percentage_ties).to eq(0.0)
         end
     end
 
     describe '#knows the number of games in a season' do
         it 'counts the games in a season' do
-        allow(@game_stats).to receive(:count_of_games_by_season).and_return({season: 20122013, games: 1}, {season: 20162017, games: 4}, {season: 20142015, games: 3})
         expect(@game_stats.count_of_games_by_season).to eq({season: 20122013, games: 1}, {season: 20162017, games: 4}, {season: 20142015, games: 3})
         end
     end
 
     describe '#calculates average goals ' do
         it 'can average the goals scored per game by both teams in every season combined' do
-        allow(@game_stats).to receive(:average_goals_per_game).and_return(4.62)
         expect(@game_stats.average_goals_per_game).to eq(4.62)
         end
 
         it 'can average the goals scored per game by both teams in a single season' do
-            allow(@game_stats).to receive(:average_goals_by_season).and_return({season: 20122013, goals: 5}, {season: 20162017, goals: 4.75}, {season: 20142015, goals: 4.33})
             expect(@game_stats.average_goals_by_season).to eq({season: 20122013, goals: 5}, {season: 20162017, goals: 4.75}, {season: 20142015, goals: 4.33})
         end
     end

--- a/spec/league_statistics_spec.rb
+++ b/spec/league_statistics_spec.rb
@@ -19,49 +19,42 @@ RSpec.describe LeagueStatistics do
   
   describe 'count_of_teams' do
     it 'counts the number of teams' do
-      allow(@league_statistics).to receive(:count_of_teams).and_return(2)
       expect(@league_statistics.count_of_teams).to eq(2)
     end
   end
 
   describe 'best_offense' do
     it 'returns the team with the highest average number of goals per game' do
-      allow(@league_statistics).to receive(:best_offense).and_return('FC Dallas')
       expect(@league_statistics.best_offense).to eq('FC Dallas')
     end
   end
 
   describe 'worst_offense' do
     it 'returns the team with the lowest average number of goals per game' do
-      allow(@league_statistics).to receive(:worst_offense).and_return('Houston Dynamo')
       expect(@league_statistics.worst_offense).to eq('Houston Dynamo')
     end
   end
 
   describe 'highest_scoring_visitor' do
     it 'returns the team with the highest average score when they are away' do
-      allow(@league_statistics).to receive(:highest_scoring_visitor).and_return('FC Dallas')
       expect(@league_statistics.highest_scoring_visitor).to eq('FC Dallas')
     end
   end
 
   describe 'highest_scoring_home_team' do
     it 'returns the team with the highest average score when they are home' do
-      allow(@league_statistics).to receive(:highest_scoring_home_team).and_return('FC Dallas')
       expect(@league_statistics.highest_scoring_home_team).to eq('FC Dallas')
     end
   end
 
   describe 'lowest_scoring_visitor' do
     it 'returns the team with the lowest average score when they are away' do
-      allow(@league_statistics).to receive(:lowest_scoring_visitor).and_return('Houston Dynamo')
       expect(@league_statistics.lowest_scoring_visitor).to eq('Houston Dynamo')
     end
   end
 
   describe 'lowest_scoring_home_team' do
     it 'returns the team with the lowest average score when they are home' do
-      allow(@league_statistics).to receive(:lowest_scoring_home_team).and_return('Houston Dynamo')
       expect(@league_statistics.lowest_scoring_home_team).to eq('Houston Dynamo')
     end
   end

--- a/spec/season_statistics_spec.rb
+++ b/spec/season_statistics_spec.rb
@@ -18,80 +18,43 @@ RSpec.describe SeasonStatistics do
 
   describe '#coach stats' do
     it 'knows the winningest coach' do
-      #allow(@season_stats).to receive(:winningest_coach).and_return('Claude Julien')
       expect(@season_stats.winningest_coach).to eq('Claude Julien')
     end
 
     it 'knows the worst coach' do
-      #allow(@season_stats).to receive(:worst_coach).and_return('John Tortorella')
       expect(@season_stats.worst_coach).to eq('John Tortorella')
     end
   end
 
   describe '#accuracy stats' do
     it 'knows the most accurate team' do
-      allow(@season_stats).to receive(:most_accurate_team).and_return('FC Dallas')
       expect(@season_stats.most_accurate_team).to eq('FC Dallas')
     end
 
     it 'knows the least accurate team' do
-      allow(@season_stats).to receive(:least_accurate_team).and_return('Houston Dynamo')
       expect(@season_stats.least_accurate_team).to eq('Houston Dynamo')
     end
   end
 
   describe '#tackle stats' do
     it 'knows the team with the most tackles' do
-      allow(@season_stats).to receive(:most_tackles).and_return('Houston Dynamo')
       expect(@season_stats.most_tackles).to eq('Houston Dynamo')
     end
 
     it 'knows the team with the fewest tackles' do
-      allow(@season_stats).to receive(:fewest_tackles).and_return('FC Dallas')
       expect(@season_stats.fewest_tackles).to eq('FC Dallas')
     end
   end
 
   describe '#load_game_data' do
-    it 'loads game data from a CSV file' do
-      mocked_csv_data = <<-CSV
-        game_id,team_id,HoA,result,settled_in,head_coach,goals,shots,tackles,pim,powerPlayOpportunities,powerPlayGoals,faceOffWinPercentage,giveaways,takeaways
-        2012030221,3,away,LOSS,OT,John Tortorella,2,8,44,8,3,0,44.8,17,7
-        2012030221,6,home,WIN,OT,Claude Julien,3,12,51,6,4,1,55.2,4,5
-        2012030222,3,away,LOSS,REG,John Tortorella,2,9,33,11,5,0,51.7,1,4
-        2012030222,6,home,WIN,REG,Claude Julien,3,8,36,19,1,0,48.3,16,6
-        2012030223,6,away,WIN,REG,Claude Julien,2,8,28,6,0,0,61.8,10,7
-        2012030223,3,home,LOSS,REG,John Tortorella,1,6,37,2,2,0,38.2,7,9
-        2012030224,6,away,WIN,OT,Claude Julien,3,10,24,8,4,2,53.7,8,6
-        2012030224,3,home,LOSS,OT,John Tortorella,2,8,40,8,4,1,46.3,9,7
-      CSV
-
-      csv_file = StringIO.new(mocked_csv_data)
-      allow(CSV).to receive(:read).and_return(CSV.parse(csv_file, headers: true, header_converters: :symbol))
-
-      @season_stats.load_game_data('path/to/mock_file.csv')
-
-      expect(@season_stats.game_data.length).to eq(8)
-      expect(@season_stats.game_data.first[:head_coach]).to eq('John Tortorella')
+    xit 'loads game data from a CSV file' do
+      # Loading data successfully should probably be tested in StatTracker?
     end
   end
 
   describe '#load_team_data' do
-    it 'loads team data from a CSV file' do
-      mocked_team_csv_data = <<-CSV
-        team_id,franchiseId,teamName,abbreviation,Stadium,link
-        3,10,Houston Dynamo,HOU,BBVA Stadium,/api/v1/teams/3
-        6,6,FC Dallas,DAL,Toyota Stadium,/api/v1/teams/6
-      CSV
-
-      csv_file = StringIO.new(mocked_team_csv_data)
-      allow(CSV).to receive(:read).and_return(CSV.parse(csv_file, headers: true, header_converters: :symbol))
-
-      @season_stats.load_team_data('path/to/mock_team_file.csv')
-
-      expect(@season_stats.team_data.length).to eq(2)
-      expect(@season_stats.team_data.first[:teamName]).to eq('Houston Dynamo')
-    end
+    xit 'loads team data from a CSV file' do
+      # Loading data successfully should probably be tested in StatTracker?
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require './lib/season_statistics'
 require 'simplecov'
 SimpleCov.start


### PR DESCRIPTION
Removes all allow statements from all tests.
Adds require 'pry' to spec_helper so pry is available everywhere.
Removes all code from testing the loading of mock game and team data in season_statistics_spec.rb.  Loading of data should probably be tested in StatTracker?